### PR TITLE
JettyRunner emulates gae.mod and gae.xml

### DIFF
--- a/appengine-jetty-managed-runtime/src/test/resources/jetty-logging.properties
+++ b/appengine-jetty-managed-runtime/src/test/resources/jetty-logging.properties
@@ -1,0 +1,4 @@
+org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
+org.eclipse.jetty.LEVEL=INFO
+org.eclipse.jetty.webapp.LEVEL=DEBUG
+org.eclipse.jetty.servlet.LEVEL=DEBUG


### PR DESCRIPTION
This is not yet working, but does run up the jetty server.

The remaining issue is where is the resourceBase/web.xml etc. for the vm context that is created?  Will each test have it's own?

