### PR TITLE
access testwebapp as dependency rather than assumed sibling

### DIFF
--- a/appengine-jetty-managed-runtime/pom.xml
+++ b/appengine-jetty-managed-runtime/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-managed-runtime</artifactId>
-      <version>1.9.23-SNAPSHOT</version>
+      <version>${project.version}</version>
       <type>jar</type>
     </dependency>
 
@@ -62,12 +62,6 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-quickstart</artifactId>
       <version>${jetty.version}</version>
-      <type>jar</type>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>tomcat-servlet-api</artifactId>
-      <version>8.0.21</version>
       <type>jar</type>
     </dependency>
     
@@ -157,7 +151,28 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <id>copy</id>
+            <id>test-webapp</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.google.appengine.demos</groupId>
+                  <artifactId>testwebapp</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <type>war</type>
+                  <overWrite>true</overWrite>
+                  <includes>**</includes>
+                  <outputDirectory>${project.build.directory}/webapps/</outputDirectory>
+                  <destFileName>testwebapp.war</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>jetty-distro</id>
             <phase>generate-resources</phase>
             <goals>
               <goal>copy</goal>
@@ -171,7 +186,7 @@
                   <type>tar.gz</type>
                   <overWrite>true</overWrite>
                   <includes>**</includes>
-                  <outputDirectory>target</outputDirectory>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
                   <destFileName>jetty-distribution.tar.gz</destFileName>
                 </artifactItem>
               </artifactItems>
@@ -179,6 +194,26 @@
           </execution>
         </executions>
       </plugin>
+      
+      
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <target>
+                <unzip src="${project.build.directory}/webapps/testwebapp.war" dest="${project.build.directory}/webapps/testwebapp"/>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      
     </plugins>
   </build>
 </project>

--- a/appengine-jetty-managed-runtime/src/test/java/com/google/apphosting/vmruntime/jetty9/JettyRunner.java
+++ b/appengine-jetty-managed-runtime/src/test/java/com/google/apphosting/vmruntime/jetty9/JettyRunner.java
@@ -118,12 +118,15 @@ class JettyRunner implements Runnable {
       // configuration from root.xml
       VmRuntimeWebAppContext context = new VmRuntimeWebAppContext();
       context.setContextPath("/");
-      // Hack to find the sibling testwebapp target
+      
+      // find the sibling testwebapp target
       File currentDir = new File("").getAbsoluteFile();
-      File webAppLocation = new File(currentDir.getParentFile(), "testwebapp/target/testwebapp-1.0-SNAPSHOT");
+      File webAppLocation = new File(currentDir, "target/webapps/testwebapp");
       context.setResourceBase(webAppLocation.getAbsolutePath());
       context.init("WEB-INF/appengine-web.xml");
       context.setParentLoaderPriority(true); // true in tests for easier mocking
+      
+      // Hack to find the webdefault.xml
       File webDefault = new File(currentDir.getParentFile(), "docker/etc/webdefault.xml");
       context.setDefaultsDescriptor(webDefault.getAbsolutePath());
      


### PR DESCRIPTION
Consume the test webapp as a maven dependency rather than as an assumed location.  Use a copy then unzip because the unpack goal of the dependency plugin produced some weird lifecycle warning. 