### PR TITLE
Add dependency for jsp for unit tests.

### DIFF
--- a/appengine-jetty-managed-runtime/pom.xml
+++ b/appengine-jetty-managed-runtime/pom.xml
@@ -67,6 +67,14 @@
     
     <!-- tests-->
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>apache-jsp</artifactId>
+      <version>${jetty.version}</version>
+      <type>jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>


### PR DESCRIPTION
Assuming the tests called "testJspNotCompiled" are indeed intended to test that a non-precompiled jsp can be compiled on the fly ... the problem was that the jsp jars were not on the test classpath.

Jan